### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import deasync from 'deasync';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import * as amqp from 'micro-node-amqp';
 import * as rpc from 'micro-node-json-rpc';
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "deasync": "^0.1.4",
     "micro-node-amqp": "^1.1.7",
     "micro-node-json-rpc": "^1.1.0",
-    "node-uuid": "^1.4.7",
-    "pkg-up": "^1.0.0"
+    "pkg-up": "^1.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.